### PR TITLE
Fixed the speech SFX pitch being driven high or low during conversations

### DIFF
--- a/Generic Components/Scenes/conversation_ui.gd
+++ b/Generic Components/Scenes/conversation_ui.gd
@@ -40,6 +40,8 @@ func _process(delta: float) -> void:
 		speech_pitch = 1.0
 	if start_displaying:
 		dialogue_label.visible_characters += 1
+		# Reset pitch to 1 for each letter. Avoids it being driven high or low
+		speech_pitch = 1.0;
 		speech_pitch += randf_range(-0.1, 0.1)
 		GlobalAudio.play_sound_id(speech_wav, "speech_audio", GlobalAudio.Bus.SFX, speech_pitch)
 

--- a/Generic Components/Scripts/monologue_ui.gd
+++ b/Generic Components/Scripts/monologue_ui.gd
@@ -23,6 +23,8 @@ func _process(delta: float) -> void:
 		speech_pitch = 1.0
 	if start_displaying:
 		dialogue_label.visible_characters += 1
+		# Reset pitch to 1 for each letter. Avoids it being driven high or low
+		speech_pitch = 1.0
 		speech_pitch += randf_range(-0.1, 0.1)
 		GlobalAudio.play_sound_id(speech_wav, "speech_audio", GlobalAudio.Bus.SFX, speech_pitch)
 


### PR DESCRIPTION
I honestly really liked when it would distort to the low end, it gave the dialogue a tone of disappointment or sadness - buut I think it would take a bit more work than it's worth right now to do this consistently and with a clear meaning. For now I reset the audio pitch to vary just a little on each letter like it was doing before. 